### PR TITLE
Fix GHA: set ISSUE_TITLE_PREFIX for Step 3 workflow

### DIFF
--- a/.github/workflows/3-step.yml
+++ b/.github/workflows/3-step.yml
@@ -12,6 +12,7 @@ permissions:
 
 env:
   STEP_4_FILE: ".github/steps/4-step.md"
+  ISSUE_TITLE_PREFIX: "Exercise:"
 
 jobs:
   find_exercise:


### PR DESCRIPTION
Sets  in  to resolve 'No exercise issue found'. This aligns with the toolkit expectation and should allow the workflow to locate the exercise issue.\n\nIf your repository uses a different prefix, update the value accordingly.